### PR TITLE
Add contact data viewer and polish UI

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -36,6 +36,21 @@ app.post('/api/contact', (req, res) => {
   });
 });
 
+// Return all stored contacts
+app.get('/api/contacts', (req, res) => {
+  fs.readFile(DATA_FILE, 'utf8', (err, data) => {
+    if (err) {
+      return res.json([]);
+    }
+    try {
+      const contacts = JSON.parse(data);
+      res.json(contacts);
+    } catch (e) {
+      res.json([]);
+    }
+  });
+});
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`Backend listening on port ${PORT}`);

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,10 +7,13 @@
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <script defer src="js/app.js"></script>
 </head>
-<body class="font-sans bg-cover bg-center bg-fixed" style="background-image: url('https://source.unsplash.com/1600x900/?technology');">
-  <header class="bg-gradient-to-r from-blue-600 to-purple-700 text-white p-8 text-center bg-opacity-80">
-    <h1 class="text-3xl font-bold">DevOps Academy Digital Consulting</h1>
-    <p class="mt-2">Transforming businesses with technology</p>
+<body class="font-sans bg-gray-100 text-gray-800">
+  <header class="relative h-64 md:h-80 bg-cover bg-center" style="background-image: url('https://source.unsplash.com/1600x900/?technology,digital');">
+    <div class="absolute inset-0 bg-blue-900 bg-opacity-60"></div>
+    <div class="relative z-10 flex flex-col items-center justify-center h-full text-center text-white">
+      <h1 class="text-3xl md:text-4xl font-bold">DevOps Academy Digital Consulting</h1>
+      <p class="mt-2">Transforming businesses with technology</p>
+    </div>
   </header>
 
   <section class="p-8 grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -49,9 +52,28 @@
         <label class="block mb-1" for="message">Message</label>
         <textarea class="w-full border p-2" id="message" required></textarea>
       </div>
-      <button class="bg-blue-600 text-white px-4 py-2" type="submit">Send</button>
+      <div class="flex flex-col sm:flex-row gap-2">
+        <button class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2" type="submit">Send</button>
+        <button type="button" id="view-submissions" class="bg-teal-600 hover:bg-teal-700 text-white px-4 py-2">View Submissions</button>
+      </div>
       <p id="status" class="mt-4 text-center"></p>
     </form>
+    <div id="submissions" class="max-w-4xl mx-auto mt-8 hidden">
+      <h3 class="text-xl font-bold mb-4 text-center">Submitted Contacts</h3>
+      <div class="overflow-x-auto">
+        <table class="min-w-full bg-white">
+          <thead>
+            <tr>
+              <th class="py-2 px-4 border-b">Name</th>
+              <th class="py-2 px-4 border-b">Email</th>
+              <th class="py-2 px-4 border-b">Message</th>
+              <th class="py-2 px-4 border-b">Timestamp</th>
+            </tr>
+          </thead>
+          <tbody id="submissions-body"></tbody>
+        </table>
+      </div>
+    </div>
   </section>
 
   <footer class="text-center p-4 text-sm text-gray-600">

--- a/frontend/public/js/app.js
+++ b/frontend/public/js/app.js
@@ -22,3 +22,28 @@ document.getElementById('contact-form').addEventListener('submit', async (e) => 
     status.textContent = 'Error sending message.';
   }
 });
+
+document.getElementById('view-submissions').addEventListener('click', async () => {
+  const section = document.getElementById('submissions');
+  if (section.classList.contains('hidden')) {
+    try {
+      const res = await fetch('/api/contacts');
+      const data = await res.json();
+      const tbody = document.getElementById('submissions-body');
+      tbody.innerHTML = '';
+      data.forEach((c) => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td class="py-2 px-4 border-b">${c.name}</td>` +
+                       `<td class="py-2 px-4 border-b">${c.email}</td>` +
+                       `<td class="py-2 px-4 border-b">${c.message}</td>` +
+                       `<td class="py-2 px-4 border-b">${new Date(c.timestamp).toLocaleString()}</td>`;
+        tbody.appendChild(tr);
+      });
+    } catch (err) {
+      console.error('Failed to load contacts', err);
+    }
+    section.classList.remove('hidden');
+  } else {
+    section.classList.add('hidden');
+  }
+});


### PR DESCRIPTION
## Summary
- add GET /api/contacts endpoint and table-driven viewer on frontend
- redesign landing page with hero image and responsive, modern layout

## Testing
- `npm test --prefix backend`
- `curl -s http://localhost:3000/api/contacts`

