### PR TITLE
Add Docker Swarm deployment guide and stack file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This sample project demonstrates Docker named volumes and Kubernetes persistent 
    ```
    The file `contacts.json` is stored inside this volume.
 
+## Docker Swarm Usage
+For step-by-step instructions on deploying this project with Docker Swarm on an EC2 instance, see the [students guide](students-guide.md).
+
 ## Kubernetes Usage
 1. Build images:
    ```sh

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+services:
+  backend:
+    image: volumebackend:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - contact_data:/data
+    deploy:
+      replicas: 1
+  frontend:
+    image: volumefrontend:latest
+    ports:
+      - "8080:80"
+    volumes:
+      - frontend_content:/usr/share/nginx/html
+    deploy:
+      replicas: 1
+volumes:
+  contact_data:
+  frontend_content:

--- a/students-guide.md
+++ b/students-guide.md
@@ -1,0 +1,53 @@
+# Students Guide: Deploying with Docker Swarm on EC2
+
+This guide walks through deploying the Docker Volumes App using Docker Swarm on an Amazon EC2 instance.
+
+## Prerequisites
+- EC2 instance with Docker engine installed
+- Security group allows inbound traffic on ports **8080** and **3000**
+- If you plan to run a multi-node swarm, a Docker registry such as Docker Hub
+
+## Steps
+1. **Connect to the EC2 instance**
+   ```sh
+   ssh ec2-user@<EC2_PUBLIC_IP>
+   ```
+2. **Initialize Docker Swarm**
+   ```sh
+   sudo docker swarm init --advertise-addr <EC2_PUBLIC_IP>
+   ```
+   Copy the join token if you will add worker nodes later.
+
+3. **Clone this repository and build the images**
+   ```sh
+   git clone https://github.com/.../Docker-volumes-app.git
+   cd Docker-volumes-app
+   sudo docker build -t volumebackend:latest backend
+   sudo docker build -t volumefrontend:latest frontend
+   ```
+   If running a multi-node swarm, push these images to a registry accessible by all nodes.
+
+4. **Deploy the stack**
+   ```sh
+   sudo docker stack deploy -c docker-stack.yml volumeapp
+   ```
+
+5. **Verify services**
+   ```sh
+   sudo docker stack services volumeapp
+   sudo docker service ls
+   ```
+
+6. **Access the application**
+   - Frontend: `http://<EC2_PUBLIC_IP>:8080`
+   - Backend API: `http://<EC2_PUBLIC_IP>:3000`
+
+7. **Clean up**
+   ```sh
+   sudo docker stack rm volumeapp
+   ```
+   Optional: `sudo docker volume ls` to inspect persistent volumes.
+
+## Notes
+- The stack file `docker-stack.yml` uses Docker named volumes to persist contact submissions.
+- For multi-node swarms, ensure volumes reside on nodes where services run or use a network storage driver.


### PR DESCRIPTION
## Summary
- add Docker Swarm stack file for backend and frontend services
- document EC2 deployment steps in a new students guide
- link swarm deployment guide from the README

## Testing
- `node --check Docker-volumes-app/backend/server.js`
